### PR TITLE
chore: replace Mapeo references with CoMapeo in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@comapeo/ipc",
   "version": "2.0.0",
-  "description": "IPC wrappers for Mapeo Core",
+  "description": "IPC wrappers for CoMapeo Core",
   "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/digidem/mapeo-ipc.git"
+    "url": "git+https://github.com/digidem/comapeo-ipc.git"
   },
   "keywords": [
     "mapeo",
@@ -36,9 +36,9 @@
   },
   "license": "MIT",
   "bugs": {
-    "url": "https://github.com/digidem/mapeo-ipc/issues"
+    "url": "https://github.com/digidem/comapeo-ipc/issues"
   },
-  "homepage": "https://github.com/digidem/mapeo-ipc#readme",
+  "homepage": "https://github.com/digidem/comapeo-ipc#readme",
   "dependencies": {
     "eventemitter3": "^5.0.1",
     "p-defer": "^4.0.0",


### PR DESCRIPTION
We renamed the repo but didn't update the info in the package.json to reflect that.