### PR TITLE
chore(ci): update release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,17 +6,24 @@ on:
       semver:
         description: 'The semver to use'
         required: true
-        default: 'patch'
+        default: 'auto'
         type: choice
         options:
+          - auto
           - patch
           - minor
           - major
+          - prerelease
+          # - prepatch
+          # - preminor
+          # - premajor
   pull_request:
     types: [closed]
+    branches: [main]
 
 jobs:
   release:
+    if: ${{github.event_name != 'pull_request' || github.event.pull_request.merged}}
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -30,13 +37,13 @@ jobs:
       - uses: nearform-actions/optic-release-automation-action@v4
         with:
           commit-message: 'Release {version}'
-          sync-semver-tags: true
+          sync-semver-tags: false
           access: 'public'
           # This prefix is added before the prerelease number, e.g. `v3.0.0-next.0`
-          prerelease-prefix: 'next'
+          # prerelease-prefix: 'alpha'
           semver: ${{ github.event.inputs.semver }}
-          # Prereleases are published under the `next` npm dist-tag
-          npm-tag: ${{ startsWith(github.event.inputs.semver, 'pre') && 'next' || 'latest' }}
+          # Prereleases are published under the `alpha` npm dist-tag
+          # npm-tag: ${{ startsWith(github.event.inputs.semver, 'pre') && 'alpha' || 'latest' }}
           # Don't notify linked issues
           notify-linked-issues: false
           # optional: set this secret in your repo config for publishing to NPM


### PR DESCRIPTION
Makes the release workflow more similar to how [core](https://github.com/digidem/comapeo-core/blob/5b1e22720a2c4c41ba1c0ed18836b5bf60a00f6a/.github/workflows/release.yml) works. the differences made the experience of using this annoyingly less useful compare to other repos.